### PR TITLE
Unit Tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,6 +410,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
 name = "elliptic-curve"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +449,7 @@ dependencies = [
  "cw20",
  "cw20-wrapped-2",
  "hex",
+ "prost",
  "sei-cosmwasm",
  "serde-json-wasm 0.4.1",
  "token-bridge-cosmwasm",
@@ -522,6 +529,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +599,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,6 +435,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bs58",
+ "cosmwasm-crypto",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 0.13.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,7 @@ dependencies = [
  "cw-utils 1.0.1",
  "cw20",
  "cw20-wrapped-2",
+ "hex",
  "sei-cosmwasm",
  "serde-json-wasm 0.4.1",
  "token-bridge-cosmwasm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,4 @@ wormhole-cosmwasm = { git = "https://github.com/wormhole-foundation/wormhole" }
 [dev-dependencies]
 cosmwasm-crypto = { version = "1.2.5" }
 hex = "0.4.3"
+prost = "0.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,4 @@ wormhole-cosmwasm = { git = "https://github.com/wormhole-foundation/wormhole" }
 
 [dev-dependencies]
 cosmwasm-crypto = { version = "1.2.5" }
+hex = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,6 @@ wormhole-cosmwasm = { version = "0.1.0", features = ["library"] }
 cw20-wrapped-2 = { git = "https://github.com/wormhole-foundation/wormhole" }
 token-bridge-cosmwasm = { git = "https://github.com/wormhole-foundation/wormhole" }
 wormhole-cosmwasm = { git = "https://github.com/wormhole-foundation/wormhole" }
+
+[dev-dependencies]
+cosmwasm-crypto = { version = "1.2.5" }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -214,7 +214,10 @@ fn convert_and_transfer(
         .load(deps.storage)
         .context("could not load token bridge contract address")?;
 
-    ensure!(info.funds.len() == 1, "no bridging coin included");
+    ensure!(
+        info.funds.len() == 1,
+        "info.funds should contain only 1 coin"
+    );
     let bridging_coin = info.funds[0].clone();
     let cw20_contract_addr = parse_bank_token_factory_contract(deps, env, bridging_coin.clone())?;
 
@@ -314,7 +317,7 @@ fn parse_bank_token_factory_contract(
         "coin is not from the token factory"
     );
 
-    // decode subdenom from base64 => encode as cosmos addr to get contract addr
+    // decode subdenom from base58 => encode as cosmos addr to get contract addr
     let cw20_contract_addr = contract_addr_from_base58(deps.as_ref(), parsed_denom[2])?;
 
     // validate that the contract does indeed match the stored denom we have for it

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 
-use anyhow::{ensure, Context};
+use anyhow::{bail, ensure, Context};
 use cosmwasm_std::{
     coin, from_binary, to_binary, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Empty, Env,
     MessageInfo, QueryRequest, Reply, Response, SubMsg, Uint128, WasmMsg, WasmQuery,
@@ -81,9 +81,8 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response<SeiMsg>, an
         return handle_complete_transfer_reply(deps, env, msg);
     }
 
-    // other cases probably from calling into the sei burn/mint messages and token factory methods
-
-    Ok(Response::default())
+    // for safety, let's error out if we don't match a reply ID
+    bail!("unmatched reply id {}", msg.id);
 }
 
 fn handle_complete_transfer_reply(

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -426,3 +426,6 @@ fn contract_addr_from_base58(deps: Deps, subdenom: &str) -> Result<String, anyho
         .map(|a| a.to_string())
         .context(format!("failed to humanize cosmos address {}", subdenom))
 }
+
+#[cfg(test)]
+mod test;

--- a/src/contract/test.rs
+++ b/src/contract/test.rs
@@ -334,7 +334,7 @@ fn complete_transfer_and_convert_no_token_bridge_state() {
     let mut deps = default_custom_mock_deps();
     let info = mock_info(SEI_USER_ADDR, &vec![]);
     let env = mock_env();
-    let vaa = Binary::from_base64("fakevaa").unwrap();
+    let vaa = Binary::from_base64("AAAAAA").unwrap();
 
     let err = complete_transfer_and_convert(deps.as_mut(), env, info, vaa).unwrap_err();
     assert_eq!(
@@ -364,7 +364,7 @@ fn complete_transfer_and_convert_failure_transferinfo_query() {
 
     let info = mock_info(SEI_USER_ADDR, &vec![]);
     let env = mock_env();
-    let vaa = Binary::from_base64("fakevaa").unwrap();
+    let vaa = Binary::from_base64("AAAAAA").unwrap();
 
     let err = complete_transfer_and_convert(deps.as_mut(), env, info, vaa).unwrap_err();
     assert_eq!(err.to_string(), "could not parse token bridge payload3 vaa");

--- a/src/contract/test.rs
+++ b/src/contract/test.rs
@@ -1,0 +1,375 @@
+use std::marker::PhantomData;
+
+use cosmwasm_std::{
+    testing::{mock_dependencies, mock_env, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR},
+    Addr, Api, Binary, CanonicalAddr, Empty, OwnedDeps, RecoverPubkeyError, StdError, StdResult,
+    VerificationError, Coin,
+};
+
+use crate::state::CW_DENOMS;
+
+use super::{contract_addr_from_base58, contract_addr_to_base58, parse_bank_token_factory_contract};
+
+pub const SEI_CONTRACT_ADDR: &str =
+    "sei1yw4wv2zqg9xkn67zvq3azye0t8h0x9kgyg3d53jym24gxt49vdyswk5upj";
+pub const SEI_USER_ADDR: &str = "sei1vhkm2qv784rulx8ylru0zpvyvw3m3cy9x3xyfv";
+pub const SEI_CONTRACT_ADDR_BYTES: [u8; 32] = [
+    0x23, 0xaa, 0xe6, 0x28, 0x40, 0x41, 0x4d, 0x69, 0xeb, 0xc2, 0x60, 0x23, 0xd1, 0x13, 0x2f, 0x59,
+    0xee, 0xf3, 0x16, 0xc8, 0x22, 0x22, 0xda, 0x46, 0x44, 0xda, 0xaa, 0x83, 0x2e, 0xa5, 0x63, 0x49,
+];
+pub const SEI_USER_ADDR_BYTES: [u8; 20] = [
+    0x65, 0xed, 0xb5, 0x01, 0x9e, 0x3d, 0x47, 0xcf, 0x98, 0xe4, 0xf8, 0xf8, 0xf1, 0x05, 0x84, 0x63,
+    0xa3, 0xb8, 0xe0, 0x85,
+];
+
+// Custom API mock implementation for testing.
+// The custom impl helps us with correct addr_validate, addr_canonicalize, and addr_humanize methods for Sei.
+#[derive(Clone)]
+pub struct CustomApi {
+    contract_addr: String,
+    user_addr: String,
+    contract_addr_bin: Binary,
+    user_addr_bin: Binary,
+}
+
+impl CustomApi {
+    pub fn new(
+        contract_addr: &str,
+        user_addr: &str,
+        contract_addr_bytes: [u8; 32],
+        user_addr_bytes: [u8; 20],
+    ) -> Self {
+        CustomApi {
+            contract_addr: contract_addr.to_string(),
+            user_addr: user_addr.to_string(),
+            contract_addr_bin: Binary::from(contract_addr_bytes),
+            user_addr_bin: Binary::from(user_addr_bytes),
+        }
+    }
+}
+
+impl Api for CustomApi {
+    fn addr_validate(&self, input: &str) -> StdResult<Addr> {
+        if input == self.contract_addr {
+            return Ok(Addr::unchecked(self.contract_addr.clone()));
+        }
+
+        if input == self.user_addr {
+            return Ok(Addr::unchecked(self.user_addr.clone()));
+        }
+
+        return Err(StdError::GenericErr {
+            msg: "case not found".to_string(),
+        });
+    }
+
+    fn addr_canonicalize(&self, input: &str) -> StdResult<CanonicalAddr> {
+        if input == self.contract_addr {
+            return Ok(CanonicalAddr(self.contract_addr_bin.clone()));
+        }
+
+        if input == self.user_addr {
+            return Ok(CanonicalAddr(self.user_addr_bin.clone()));
+        }
+
+        return Err(StdError::GenericErr {
+            msg: "case not found".to_string(),
+        });
+    }
+
+    fn addr_humanize(&self, canonical: &CanonicalAddr) -> StdResult<Addr> {
+        if *canonical == self.contract_addr_bin {
+            return Ok(Addr::unchecked(self.contract_addr.clone()));
+        }
+
+        if *canonical == self.user_addr_bin {
+            return Ok(Addr::unchecked(self.user_addr.clone()));
+        }
+
+        return Err(StdError::GenericErr {
+            msg: "case not found".to_string(),
+        });
+    }
+
+    fn secp256k1_verify(
+        &self,
+        message_hash: &[u8],
+        signature: &[u8],
+        public_key: &[u8],
+    ) -> Result<bool, VerificationError> {
+        Ok(cosmwasm_crypto::secp256k1_verify(
+            message_hash,
+            signature,
+            public_key,
+        )?)
+    }
+
+    fn secp256k1_recover_pubkey(
+        &self,
+        message_hash: &[u8],
+        signature: &[u8],
+        recovery_param: u8,
+    ) -> Result<Vec<u8>, RecoverPubkeyError> {
+        let pubkey =
+            cosmwasm_crypto::secp256k1_recover_pubkey(message_hash, signature, recovery_param)?;
+        Ok(pubkey.to_vec())
+    }
+
+    fn ed25519_verify(
+        &self,
+        message: &[u8],
+        signature: &[u8],
+        public_key: &[u8],
+    ) -> Result<bool, VerificationError> {
+        Ok(cosmwasm_crypto::ed25519_verify(
+            message, signature, public_key,
+        )?)
+    }
+
+    fn ed25519_batch_verify(
+        &self,
+        messages: &[&[u8]],
+        signatures: &[&[u8]],
+        public_keys: &[&[u8]],
+    ) -> Result<bool, VerificationError> {
+        Ok(cosmwasm_crypto::ed25519_batch_verify(
+            messages,
+            signatures,
+            public_keys,
+        )?)
+    }
+
+    fn debug(&self, message: &str) {
+        println!("{}", message);
+    }
+}
+
+fn default_custom_mock_deps() -> OwnedDeps<MockStorage, CustomApi, MockQuerier, Empty> {
+    custom_mock_deps(
+        SEI_CONTRACT_ADDR,
+        SEI_USER_ADDR,
+        SEI_CONTRACT_ADDR_BYTES,
+        SEI_USER_ADDR_BYTES,
+    )
+}
+
+fn custom_mock_deps(
+    contract_addr: &str,
+    user_addr: &str,
+    contract_addr_bytes: [u8; 32],
+    user_addr_bytes: [u8; 20],
+) -> OwnedDeps<MockStorage, CustomApi, MockQuerier, Empty> {
+    OwnedDeps {
+        storage: MockStorage::default(),
+        api: CustomApi::new(
+            contract_addr,
+            user_addr,
+            contract_addr_bytes,
+            user_addr_bytes,
+        ),
+        querier: MockQuerier::default(),
+        custom_query_type: PhantomData,
+    }
+}
+
+// methods to test:
+//
+// instantiate
+// migrate
+//
+// EXECUTE METHODS:
+// execute
+// complete_transfer_and_convert
+// convert_and_transfer
+// convert_bank_to_cw20
+// handle_receiver_msg
+// convert_cw20_to_bank
+//
+// REPLY METHODS:
+// reply
+// handle_complete_transfer_reply
+//
+// HELPER METHODS:
+// parse_bank_token_factory_contract
+// contract_addr_to_base58
+// contract_addr_from_base58
+
+// TESTS: instantiate
+// 1. Happy path, ensure everything is set
+
+// TESTS: migrate
+// 1. Happy path, nothing should happen
+
+// TESTS: execute
+// 1. Ensure each message calls the correct method
+
+// TESTS: complete_transfer_and_convert
+// 1. Happy path
+// 2. Failure: no token bridge address in state
+// 3. Failure: couldn't serialize token bridge execute msg
+// 4. Failure: couldn't serialize token bridge query msg
+// 5. Failure: token bridge query TransferInfo failed
+// 6. Failure: could not humanize recipient address
+// 7. Failure: recipient address doesn't match contract address
+// 8. Failure: couldn't save current transfer to storage
+
+// TESTS: convert_and_transfer
+// 1. Happy path
+// 2. Failure: no token bridge address in state
+// 3. Failure: no coin in funds
+// 4. Failure: more coins than expected in funds
+// 5. Failure: parse_bank_token_factory_contract method failure
+// 6. Failure: couldn't serialize IncreaseAllowance msg
+// 7. Failure: couldn't serialize InitiateTransfer msg
+
+// TESTS: convert_bank_to_cw20
+// 1. Happy path
+// 2. Failure: no coin in funds
+// 3. Failure: more coins than expected in funds
+// 4. Failure: parse_bank_token_factory_contract method failure
+// 5. Failure: couldn't serialize cw20::Transfer msg
+
+// TESTS: handle_receiver_msg
+// 1. Happy path
+// 2. Failure: couldn't parse receive action payload
+
+// TESTS: convert_cw20_to_bank
+// 1. Happy path
+// 2. Happy path + CreateDenom on TokenFactory
+// 3. Failure: couldn't validate recipient address
+// 4. Failure: couldn't validate contract address
+// 5. Failure: contract_addr_to_base58 method failure
+// 6. Failure: couldn't save contract addr => tokenfactory mapping to storage
+
+// TESTS: reply
+// 1. Happy path: REPLY ID matches
+// 2. ID does not match reply -- no op
+
+// TESTS: handle_complete_transfer_reply
+// 1. Happy path: calls convert_cw20_to_bank
+// 2. Failure: msg result is not okay
+// 3. Failure: could not parse reply response_data
+// 4. Failure: no data in the parsed response
+// 5. Failure: could not deserialize response data
+// 6. Failure: no contract in the response
+// 7. Failure: no current transfer in storage
+// 8. Failure: could not deserialize payload3 payload from stored transfer
+// 9. Failure: could not convert the recipient base64 encoded bytes to a utf8 string
+
+// TESTS: parse_bank_token_factory_contract
+// 1. Happy path
+#[test]
+fn parse_bank_token_factory_contract_happy_path() {
+    let mut deps = default_custom_mock_deps();
+    let env = mock_env();
+
+    let tokenfactory_denom = format!("factory/{}/{}", MOCK_CONTRACT_ADDR, "3QEQyi7iyJHwQ4wfUMLFPB4kRzczMAXCitWh7h6TETDa");
+    let coin = Coin::new(100, tokenfactory_denom.clone());
+    CW_DENOMS.save(deps.as_mut().storage, SEI_CONTRACT_ADDR.to_string(), &tokenfactory_denom).unwrap();
+
+    let contract_addr = parse_bank_token_factory_contract(deps.as_mut(), env, coin).unwrap();
+    assert_eq!(contract_addr, SEI_CONTRACT_ADDR);
+}
+
+// 2. Failure: parsed denom not of length 3
+#[test]
+fn parse_bank_token_factory_contract_failure_denom_length() {
+    let mut deps = default_custom_mock_deps();
+    let env = mock_env();
+    let coin = Coin::new(100, "tokenfactory/denom");
+
+    let method_err = parse_bank_token_factory_contract(deps.as_mut(), env, coin).unwrap_err();
+    assert_eq!(method_err.to_string(), "coin is not from the token factory");
+}
+
+// 3. Failure: parsed denom[0] != "factory"
+#[test]
+fn parse_bank_token_factory_contract_failure_non_factory_token() {
+    let mut deps = default_custom_mock_deps();
+    let env = mock_env();
+    let coin = Coin::new(100, "tokenfactory/contract/denom");
+
+    let method_err = parse_bank_token_factory_contract(deps.as_mut(), env, coin).unwrap_err();
+    assert_eq!(method_err.to_string(), "coin is not from the token factory");
+}
+
+// 4. Failure: parsed denom[1] != contract address
+#[test]
+fn parse_bank_token_factory_contract_failure_non_contract_created() {
+    let mut deps = default_custom_mock_deps();
+    let env = mock_env();
+    let coin = Coin::new(100, "factory/contract/denom");
+
+    let method_err = parse_bank_token_factory_contract(deps.as_mut(), env, coin).unwrap_err();
+    assert_eq!(method_err.to_string(), "coin is not from the token factory");
+}
+
+// 5. Failure: contract_addr_from_base58 method failure
+#[test]
+fn parse_bank_token_factory_contract_failure_base58_decode_failure() {
+    let mut deps = default_custom_mock_deps();
+    let env = mock_env();
+    let coin = Coin::new(100, format!("factory/{}/denom0", MOCK_CONTRACT_ADDR));
+
+    let method_err = parse_bank_token_factory_contract(deps.as_mut(), env, coin).unwrap_err();
+    assert_eq!(method_err.to_string(), "failed to decode base58 subdenom denom0");
+}
+
+// 6. Failure: the parsed contract address is not in CW_DENOMS storage
+#[test]
+fn parse_bank_token_factory_contract_failure_no_storage() {
+    let mut deps = default_custom_mock_deps();
+    let env = mock_env();
+    let coin = Coin::new(100, format!("factory/{}/{}", MOCK_CONTRACT_ADDR, "3QEQyi7iyJHwQ4wfUMLFPB4kRzczMAXCitWh7h6TETDa"));
+
+    let method_err = parse_bank_token_factory_contract(deps.as_mut(), env, coin).unwrap_err();
+    assert_eq!(method_err.to_string(), "a corresponding denom for the extracted contract addr is not contained in storage");
+}
+
+// 7. Failure: the stored denom doesn't equal the coin's denom
+#[test]
+fn parse_bank_token_factory_contract_failure_storage_mismatch() {
+    let mut deps = default_custom_mock_deps();
+    let env = mock_env();
+    let coin = Coin::new(100, format!("factory/{}/{}", MOCK_CONTRACT_ADDR, "3QEQyi7iyJHwQ4wfUMLFPB4kRzczMAXCitWh7h6TETDa"));
+
+    CW_DENOMS.save(deps.as_mut().storage, SEI_CONTRACT_ADDR.to_string(), &"factory/fake/fake".to_string()).unwrap();
+
+    let method_err = parse_bank_token_factory_contract(deps.as_mut(), env, coin).unwrap_err();
+    assert_eq!(method_err.to_string(), "the stored denom for the contract does not match the actual coin denom");
+}
+
+// TESTS: contract_addr_to_base58
+// 1. Happy path: convert to base58
+#[test]
+fn contract_addr_to_base58_happy_path() {
+    let deps = default_custom_mock_deps();
+    let b58_str = contract_addr_to_base58(
+        deps.as_ref(),
+        "sei1yw4wv2zqg9xkn67zvq3azye0t8h0x9kgyg3d53jym24gxt49vdyswk5upj".to_string(),
+    ).unwrap();
+    assert_eq!(b58_str, "3QEQyi7iyJHwQ4wfUMLFPB4kRzczMAXCitWh7h6TETDa");
+}
+
+// TESTS: contract_addr_from_base58
+// 1. Happy path: convert to contract address
+#[test]
+fn contract_addr_from_base58_happy_path() {
+    let deps = default_custom_mock_deps();
+    let contract_addr = contract_addr_from_base58(
+        deps.as_ref(),
+        "3QEQyi7iyJHwQ4wfUMLFPB4kRzczMAXCitWh7h6TETDa",
+    ).unwrap();
+    assert_eq!(contract_addr, "sei1yw4wv2zqg9xkn67zvq3azye0t8h0x9kgyg3d53jym24gxt49vdyswk5upj");
+}
+
+// 2. Failure: could not decode base58
+#[test]
+fn contract_addr_from_base58_failure_decode_base58() {
+    let deps = default_custom_mock_deps();
+    let method_err = contract_addr_from_base58(
+        deps.as_ref(),
+        "3QEQyi7iyJHwQ4wfUMLFPB4kRzczMAXCitWh7h6TETD0",
+    ).unwrap_err();
+    assert_eq!(method_err.to_string(), "failed to decode base58 subdenom 3QEQyi7iyJHwQ4wfUMLFPB4kRzczMAXCitWh7h6TETD0")
+}


### PR DESCRIPTION
This PR adds unit tests for the cosmwasm contract.

It also includes 3 minor updates to the contract itself:
1. Updated comment in `parse_bank_token_factory_contract`
2. Updated error message in `convert_and_transfer`
3. For extra defense in depth, return an error in the `reply` handler when the `reply.id` is not matched.